### PR TITLE
ci: replace broken engineerd/setup-kind@v0.6.2 with helm/kind-action@v1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,9 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: engineerd/setup-kind@v0.6.2
+      - uses: helm/kind-action@v1
         with:
-          version: "v0.11.1"
+          kind_version: "v0.11.1"
 
       - name: Kubernetes Testing
         run: |


### PR DESCRIPTION
## Summary

The CI job has been failing on **every** PR — including dependabot bumps that don't touch the workflow — because the pinned action `engineerd/setup-kind@v0.6.2` is broken: its release artifact `dist/main/index.js` returns 404.

```text
File not found: '/home/runner/work/_actions/engineerd/setup-kind/v0.6.2/dist/main/index.js'
```

This PR replaces it with `helm/kind-action@v1`, the official Helm-org-maintained Kind setup action. The only API difference is the input parameter `version` → `kind_version`.

## Why this matters here

Unlike the same pattern in `helm-kcl`, this workflow actually uses the kind cluster downstream — the `Kubernetes Testing` and `Run e2e tests` steps rely on it. So this fix isn't just about unblocking CI; it's about making the existing e2e tests actually run.